### PR TITLE
fix: change navigation drawer to render icons

### DIFF
--- a/app/views/material_design/navigation/_navigation_drawer.html.erb
+++ b/app/views/material_design/navigation/_navigation_drawer.html.erb
@@ -5,9 +5,7 @@
     <% section[:nav_items].each do |nav_item| %>
       <%= link_to nav_item[:href], class: class_names("navigation-drawer__nav_item", { active: request.fullpath.start_with?(nav_item[:href]) }) do %>
         <div class="navigation-drawer__state-layer">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 18C15.3137 18 18 15.3137 18 12C18 8.68629 15.3137 6 12 6C8.68629 6 6 8.68629 6 12C6 15.3137 8.68629 18 12 18Z" fill="currentcolor  "/>
-          </svg>
+          <%= render "material_design/icons/#{nav_item[:icon]}", locals: { size: 24, icon: nav_item[:icon] } %>
           <div style="flex: 1 0 0;">
             <%= render "material_design/typography/label_large", locals: { label: nav_item[:label] } %>
           </div>

--- a/app/views/material_design/navigation/_navigation_drawer.html.erb
+++ b/app/views/material_design/navigation/_navigation_drawer.html.erb
@@ -5,7 +5,7 @@
     <% section[:nav_items].each do |nav_item| %>
       <%= link_to nav_item[:href], class: class_names("navigation-drawer__nav_item", { active: request.fullpath.start_with?(nav_item[:href]) }) do %>
         <div class="navigation-drawer__state-layer">
-          <%= render "material_design/icons/#{nav_item[:icon]}", locals: { size: 24, icon: nav_item[:icon] } %>
+          <%= render "material_design/icons/icon", locals: { size: 24, icon: nav_item[:icon] } %>
           <div style="flex: 1 0 0;">
             <%= render "material_design/typography/label_large", locals: { label: nav_item[:label] } %>
           </div>


### PR DESCRIPTION
# Description

- Update navigation drawer to render _icon partial passing locals: { size: 24, icon: nav_item[:icon] }

## Why these changes are being made

- Navigation drawer should use material icons to reflect their content

## Jira Card

[Update all icons from navigation drawer](https://carrybits.atlassian.net/jira/software/projects/CB/boards/1?selectedIssue=CB-147)

