### PR TITLE
refactor: remove unused turbo frame tag parameter from tabs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    material_design (0.4.4)
+    material_design (0.4.6)
       rails (>= 7.1.3)
 
 GEM

--- a/app/views/material_design/tabs/_secondary.html.erb
+++ b/app/views/material_design/tabs/_secondary.html.erb
@@ -1,6 +1,6 @@
 <div class="secondary-tabs--container">
   <% locals[:tabs].each do |tab| %>
-    <%= render "material_design/tabs/secondary/tab", locals: { label: tab[:label], path: tab[:path], turbo_frame_tag: locals[:turbo_frame_tag] } %>
+    <%= render "material_design/tabs/secondary/tab", locals: { label: tab[:label], path: tab[:path] } %>
   <% end %>
 </div>
 <%= render "material_design/dividers/horizontal", locals: { inset: false } %>

--- a/app/views/material_design/tabs/secondary/_tab.html.erb
+++ b/app/views/material_design/tabs/secondary/_tab.html.erb
@@ -1,3 +1,3 @@
-<%= link_to locals[:path], data: { turbo_frame: locals[:turbo_frame_tag] }, class: class_names('secondary-tabs--tab', active: request.fullpath.start_with?(locals[:path])) do %>
+<%= link_to locals[:path], class: class_names('secondary-tabs--tab', active: request.fullpath.start_with?(locals[:path])) do %>
   <%= render "material_design/typography/title_small", locals: { title: locals[:label] } %>
 <% end %>


### PR DESCRIPTION
# What is the branch type?

- refactor

# Description

- Remove local param `turbo_frame_tag`

## Why these changes are being made

- `tabs` component does not need a `turbo_frame_tag` parameter because the `tabs` component will be rendered inside the turbo frame itself

## Jira Card

- N/A

## Screenshots

- N/A
