### PR TITLE
hotfix: remane filter-chip classes and add .chip class for partial component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    material_design (0.9.0)
+    material_design (0.9.1)
       importmap-rails
       rails (>= 7.1.3)
       stimulus-rails

--- a/app/assets/stylesheets/material_design/chips.css
+++ b/app/assets/stylesheets/material_design/chips.css
@@ -32,6 +32,27 @@
 }
 
 .chip {
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+
+  @media (prefers-color-scheme: light) {
+    background: rgb(var(--md-sys-light-secondary-fixed));
+    color: rgb(var(--md-sys-dark-on-secondary-fixed));
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background: rgb(var(--md-sys-dark-secondary-fixed));
+    color: rgb(var(--md-sys-dark-on-secondary-fixed));
+  }
+}
+
+.filter-chip {
   align-items: center;
   border-radius: 8px;
   cursor: pointer;
@@ -50,13 +71,13 @@
   }
 }
 
-.chip:hover {
+.filter-chip:hover {
   background: var(--md-sys-hover-layer-state)
     radial-gradient(circle, transparent 1%, var(--md-sys-hover-layer-state) 1%)
     center/15000%;
 }
 
-.chip.selected {
+.filter-chip.selected {
   border-color: transparent;
   @media (prefers-color-scheme: light) {
     background: rgb(var(--md-sys-light-secondary-container));
@@ -69,7 +90,7 @@
   }
 }
 
-.chip.selected:hover {
+.filter-chip.selected:hover {
   background: var(--md-sys-hover-selected-state)
     radial-gradient(
       circle,
@@ -79,7 +100,7 @@
     center/15000%;
 }
 
-.chip__container {
+.filter-chip__container {
   box-sizing: border-box;
   display: inline-block;
   margin: 0;
@@ -87,7 +108,7 @@
   vertical-align: middle;
 }
 
-.chip__dropdown {
+.filter-chip__dropdown {
   box-sizing: border-box;
   display: block;
   max-width: calc(100vw - 60px);
@@ -98,12 +119,12 @@
 }
 
 @media (min-width: 768px) {
-  .chip__dropdown {
+  .filter-chip__dropdown {
     max-width: calc(100vw - 140px);
   }
 }
 
-.chip__label {
+.filter-chip__label {
   font-size: 14px;
   font-weight: 500;
   padding: 0px 8px;

--- a/app/helpers/material_design/chip_helper.rb
+++ b/app/helpers/material_design/chip_helper.rb
@@ -3,15 +3,15 @@ module MaterialDesign
     def md_filter_chip(label=nil, leading_icon: nil, trailing_icon: nil, selected: false, data: {}, style: nil, &block)
       merged_data = data.merge(controller: "filter-chip", filter_chip_selected_value: selected, action: "#{block_given? ? "click->filter-chip#toggleDropdown" : "click->filter-chip#toggleSelect"}")
 
-      chip_content = content_tag(:div, class: "chip__container", data: merged_data) do
-        concat(content_tag(:div, class: class_names("chip", selected: selected), data: { filter_chip_target: "chip"}, style: style) do
+      chip_content = content_tag(:div, class: "filter-chip__container", data: merged_data) do
+        concat(content_tag(:div, class: class_names("filter-chip", selected: selected), data: { filter_chip_target: "chip"}, style: style) do
           concat(content_tag(:span, class: "dropdown--hidden", data: {filter_chip_target: "selectedIcon"}) do
             render("material_design/icons/icon", locals: { icon: "check", size: 18 })
           end)
           concat(content_tag(:span, data: {filter_chip_target: "leadingIcon"}) do
             render("material_design/icons/icon", locals: { icon: leading_icon, size: 18 }) if leading_icon
           end)
-          concat(content_tag(:p, label, class: "chip__label", data: {filter_chip_target: "label"}))
+          concat(content_tag(:p, label, class: "filter-chip__label", data: {filter_chip_target: "label"}))
           concat(content_tag(:span, data: {filter_chip_target: "chevronIcon"}) do
             render("material_design/icons/icon", locals: { icon: "arrow_drop_down", size: 18 })
           end) if block_given?
@@ -20,7 +20,7 @@ module MaterialDesign
           end)
         end)
         if block_given?
-          concat(content_tag(:div,  class: "dropdown--hidden chip__dropdown", data: {filter_chip_target: "dropdown"}) do
+          concat(content_tag(:div,  class: "dropdown--hidden filter-chip__dropdown", data: {filter_chip_target: "dropdown"}) do
             capture(&block)
           end)
         end

--- a/lib/material_design/version.rb
+++ b/lib/material_design/version.rb
@@ -1,3 +1,3 @@
 module MaterialDesign
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
# What is the branch type?

- fix

# Description

-  Rename filter chip css classes from "chip(...)" to "filter-chip(...)";
-  Return .chip class to style common chip, rendered by partial

## Why these changes are being made

- Chip in question cards are incorrectly styled;

## Jira Card

- 

## Screenshots

-
